### PR TITLE
feat: 起動時にスクリプト本体の更新を確認し、更新が必要であれば最新版にして実行する

### DIFF
--- a/aviutl-installer.cmd
+++ b/aviutl-installer.cmd
@@ -62,7 +62,7 @@ if ($tagName -ne $Version) {
 	# 展開後のzipを削除
 	Remove-Item aviutl-installer_$($tagName).zip
     # 新バージョンのファイル(aviutl-installer.cmd 以外)をルードディレクトリに移動(Force)
-    Get-ChildItem -Path "aviutl-installer_$tagName" | Where-Object { $_.Name -ne "aviutl-installer.cmd" } | Move-Item -Destination $scriptFileRoot -Force | Out-Null
+    Get-ChildItem -Path "aviutl-installer_$tagName" -Recurse | Where-Object { $_.Name -ne "aviutl-installer.cmd" } | Move-Item -Destination $scriptFileRoot -Force | Out-Null
 	# 競合防止でtmpフォルダを削除
 	Remove-Item -Path tmp -Recurse -Force | Out-Null
 	# 一旦ウィンドウをクリア(Host.UI.RauUI.WindowTitleとコンソールをクリア)にする

--- a/aviutl-installer.cmd
+++ b/aviutl-installer.cmd
@@ -790,7 +790,7 @@ $DesktopWshShell = New-Object -comObject WScript.Shell
 $DesktopShortcut = $DesktopWshShell.CreateShortcut($DesktopShortcutFile)
 $DesktopShortcut.TargetPath = "C:\Applications\AviUtl\aviutl.exe"
 $DesktopShortcut.IconLocation = "C:\Applications\AviUtl\aviutl.exe,0"
-$DesktopShortcut.WorkingDirectory = "."
+$DesktopShortcut.WorkingDirectory = "C:\Applications\AviUtl"
 $DesktopShortcut.Save()
 
 Write-Host "Š®—¹"
@@ -803,7 +803,7 @@ $ProgramsWshShell = New-Object -comObject WScript.Shell
 $ProgramsShortcut = $ProgramsWshShell.CreateShortcut($ProgramsShortcutFile)
 $ProgramsShortcut.TargetPath = "C:\Applications\AviUtl\aviutl.exe"
 $ProgramsShortcut.IconLocation = "C:\Applications\AviUtl\aviutl.exe,0"
-$ProgramsShortcut.WorkingDirectory = "."
+$ProgramsShortcut.WorkingDirectory = "C:\Applications\AviUtl"
 $ProgramsShortcut.Save()
 
 Write-Host "Š®—¹"


### PR DESCRIPTION
スクリプトが起動され、インストール動作を行う前に、スクリプト本体の更新を確認し、必要であれば最新版に更新してもう一度実行するように改良しました。

### 検証環境
- Windows11 24H2 26100.2605
- Intel Core i5-1135G7
- Intel Iris Xe Graphics

### 懸念点(解決、、、？)
最新版のファイルを置くフォルダはどうしてもフォルダをずらさなければいけない(というか、現在実行中のファイルを上書きすることはできない)。そうすると、必須プラグイン・スクリプトを更新する.cmdにユーザーがアクセスしにくくなる可能性が大いにある。
[このCommit](https://github.com/menndouyukkuri/aviutl-installer-script/pull/10#issuecomment-2606840621)で解決された可能性があります。

というデメリットもあるため、この点も含め、実装するかどうかの判断、評価をお願いします。

20:36 表記を修正