### PR TITLE
一時フォルダ領域の場所を変更

### DIFF
--- a/aviutl-installer.cmd
+++ b/aviutl-installer.cmd
@@ -54,6 +54,9 @@ param (
 	[string]$Path = "C:\Applications\AviUtl"
 )
 
+# 一時作業フォルダをUserProfile側のTempに展開するように設定 by Atolycs
+# これ以降の一時作業フォルダの場所はスクリプトとは別の場所に保存
+
 function New-TempDirectory() {
   $path = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
   while (Test-Path $path) {
@@ -251,10 +254,10 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n一時的にファイルを保管するフォルダを作成しています..."
 
 	# tmp ディレクトリを作成する (待機)
-	Start-Process powershell -ArgumentList "-command New-Item ${TempPath} -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
+	# Start-Process powershell -ArgumentList "-command New-Item ${TempPath} -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを tmp ディレクトリに変更
-	Set-Location tmp
+	Set-Location ${TempPath}
 
 	Write-Host "完了"
 	Write-Host -NoNewline "`r`nフォルダーオプションを確認しています..."
@@ -1079,9 +1082,10 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nインストールに使用した不要なファイルを削除しています..."
 
 	# カレントディレクトリをスクリプトファイルのあるディレクトリに変更
-	#Set-Location ..
+	Set-Location ${Path}
 
-	# tmp ディレクトリを削除
+	# tmp ディレクトリを削除 (By 20250307 Atolycs)
+  # UserProfileに作成した一時フォルダを削除
 	Remove-Item ${TempPath} -Recurse
 
 	Write-Host "完了"

--- a/aviutl-installer.cmd
+++ b/aviutl-installer.cmd
@@ -56,6 +56,10 @@ param (
 
 function New-TempDirectory() {
   $path = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+  while (Test-Path $path) {
+    $path = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+  }
+  New-Item -ItemType Directory -Path $path
 }
 
 $TempPath = New-TempDirectory

--- a/aviutl-installer.cmd
+++ b/aviutl-installer.cmd
@@ -130,13 +130,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	$AISDownloadUrl = $AisGithubApi.assets.browser_download_url
 
 	# 本体のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $AISDownloadUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $AISDownloadUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# $AisTagName から先頭の「v」を削除
 	$AisTagName = $AisTagName.Substring(1)
 
 	# 本体のzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl-installer_$AisTagName.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl-installer_$AisTagName.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# 展開後のzipを削除
 	Remove-Item aviutl-installer_$($AisTagName).zip
@@ -238,16 +238,16 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nAviUtlをインストールするフォルダを作成しています..."
 
 	# $Path ディレクトリを作成する (待機)
-	Start-Process powershell -ArgumentList "-command New-Item $Path -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item $Path -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に plugins, script, license, readme の4つのディレクトリを作成する (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\plugins`", `"${Path}\script`", `"${Path}\license`", `"${Path}\readme`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\plugins`", `"${Path}\script`", `"${Path}\license`", `"${Path}\readme`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "`r`n一時的にファイルを保管するフォルダを作成しています..."
 
 	# tmp ディレクトリを作成する (待機)
-	Start-Process powershell -ArgumentList "-command New-Item ($TempPath) -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item ${TempPath} -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを tmp ディレクトリに変更
 	Set-Location tmp
@@ -262,14 +262,14 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "「登録されている拡張子は表示しない」を無効にしています..."
 
 		# C:\Applications\AviUtl-Installer-Script ディレクトリを作成する (待機)
-		Start-Process powershell -ArgumentList "-command New-Item `"C:\Applications\AviUtl-Installer-Script`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+		Start-Process powershell -ArgumentList "-command New-Item `"C:\Applications\AviUtl-Installer-Script`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 		# "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion" をバックアップ (待機)
-		Start-Process powershell -ArgumentList "-command reg export `"HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion`" `"C:\Applications\AviUtl-Installer-Script\Backup.reg`"" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+		Start-Process powershell -ArgumentList "-command reg export `"HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion`" `"C:\Applications\AviUtl-Installer-Script\Backup.reg`"" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 		# "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" がない場合、作成する (待機)
 		if (!(Test-Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced")) {
-			Start-Process powershell -ArgumentList "-command New-Item `"HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+			Start-Process powershell -ArgumentList "-command New-Item `"HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 		}
 
 		# レジストリを書き換えて「登録されている拡張子は表示しない」を無効化
@@ -280,19 +280,19 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nAviUtl本体 (version 1.10) をダウンロードしています..."
 
 	# AviUtl version 1.10のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/aviutl110.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/aviutl110.zip" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "AviUtl本体をインストールしています..."
 
 	# AviUtlのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl110.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl110.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを aviutl110 ディレクトリに変更
 	Set-Location aviutl110
 
 	# AviUtl\readme 内に aviutl ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\aviutl`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\aviutl`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に aviutl.exe と aviutl.txt を移動
 	Move-Item "aviutl.exe", "aviutl.txt" $Path -Force
@@ -307,22 +307,22 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n拡張編集Plugin version 0.92をダウンロードしています..."
 
 	# 拡張編集Plugin version 0.92のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/exedit92.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/exedit92.zip" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "拡張編集Pluginをインストールしています..."
 
 	# 拡張編集Pluginのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path exedit92.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path exedit92.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを exedit92 ディレクトリに変更
 	Set-Location exedit92
 
 	# AviUtl\readme 内に exedit ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\exedit`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\exedit`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# exedit.ini は使用せず、かつこの後の処理で邪魔になるので削除する (待機)
-	Start-Process powershell -ArgumentList "-command Remove-Item exedit.ini" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Remove-Item exedit.ini" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内にファイルを全て移動
 	Move-Item * $Path -Force
@@ -347,22 +347,22 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "patch.aul (謎さうなフォーク版) をダウンロードしています..."
 
 	# patch.aul (謎さうなフォーク版) のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $patchAulUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $patchAulUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "patch.aul (謎さうなフォーク版) をインストールしています..."
 
 	# patch.aulのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path patch.aul_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path patch.aul_*.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをpatch.aulのzipファイルを展開したディレクトリに変更
 	Set-Location "patch.aul_*"
 
 	# AviUtl\license 内に patch-aul ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\license\patch-aul`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\license\patch-aul`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に patch.aul を (待機) 、AviUtl\license\patch-aul 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item patch.aul $Path -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item patch.aul $Path -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\license\patch-aul" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -388,7 +388,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "L-SMASH Works (Mr-Ojii版) をダウンロードしています..."
 
 	# L-SMASH Works (Mr-Ojii版) のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $lSmashWorksUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $lSmashWorksUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "L-SMASH Works (Mr-Ojii版) をインストールしています..."
@@ -399,17 +399,17 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# L-SMASH Worksのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path L-SMASH-Works_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path L-SMASH-Works_*.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをL-SMASH Worksのzipファイルを展開したディレクトリに変更
 	Set-Location "L-SMASH-Works_*"
 
 	# AviUtl\readme, AviUtl\license 内に l-smash_works ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\l-smash_works`", `"${Path}\license\l-smash_works`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\l-smash_works`", `"${Path}\license\l-smash_works`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\plugins ディレクトリ内に lw*.au* を、AviUtl\readme\l-smash_works 内に READM* を (待機) 、
 	# AviUtl\license\l-smash_works 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item lw*.au* `"${Path}\plugins`" -Force; Move-Item READM* `"${Path}\readme\l-smash_works`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item lw*.au* `"${Path}\plugins`" -Force; Move-Item READM* `"${Path}\readme\l-smash_works`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\license\l-smash_works" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -439,23 +439,23 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "InputPipePluginをダウンロードしています..."
 
 	# InputPipePluginのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $InputPipePluginUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $InputPipePluginUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "InputPipePluginをインストールしています..."
 
 	# InputPipePluginのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path InputPipePlugin_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path InputPipePlugin_*.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをInputPipePluginのzipファイルを展開したディレクトリに変更
 	Set-Location "InputPipePlugin_*\InputPipePlugin"
 
 	# AviUtl\readme, AviUtl\license 内に inputPipePlugin ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\inputPipePlugin`", `"${Path}\license\inputPipePlugin`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\inputPipePlugin`", `"${Path}\license\inputPipePlugin`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\license\inputPipePlugin 内に LICENSE を、AviUtl\readme\inputPipePlugin 内に Readme.md を (待機) 、
 	# AviUtl\plugins ディレクトリ内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\inputPipePlugin`" -Force; Move-Item Readme.md `"${Path}\readme\inputPipePlugin`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\inputPipePlugin`" -Force; Move-Item Readme.md `"${Path}\readme\inputPipePlugin`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\plugins" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -475,7 +475,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "x264guiExをダウンロードしています..."
 
 	# x264guiExのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $x264guiExUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $x264guiExUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "x264guiExをインストールしています..."
@@ -486,7 +486,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# x264guiExのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path x264guiEx_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path x264guiEx_*.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをx264guiExのzipファイルを展開したディレクトリに変更
 	Set-Location "x264guiEx_*\x264guiEx_*"
@@ -501,7 +501,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Set-Location ..\exe_files
 
 	# AviUtl ディレクトリ内に exe_files ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\exe_files`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\exe_files`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\exe_files 内に現在のディレクトリのファイルを全て移動
 	Move-Item * "${Path}\exe_files" -Force
@@ -510,7 +510,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Set-Location ..
 
 	# AviUtl\readme 内に x264guiEx ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\x264guiEx`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\x264guiEx`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\readme\x264guiEx 内に x264guiEx_readme.txt を移動
 	Move-Item x264guiEx_readme.txt "${Path}\readme\x264guiEx" -Force
@@ -532,23 +532,23 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "MFVideoReaderをダウンロードしています..."
 
 	# MFVideoReaderのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $MFVideoReaderUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $MFVideoReaderUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "MFVideoReaderをインストールしています..."
 
 	# MFVideoReaderのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path MFVideoReader_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path MFVideoReader_*.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをMFVideoReaderのzipファイルを展開したディレクトリに変更
 	Set-Location "MFVideoReader_*\MFVideoReader"
 
 	# AviUtl\readme, AviUtl\license 内に MFVideoReader ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\MFVideoReader`", `"${Path}\license\MFVideoReader`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\MFVideoReader`", `"${Path}\license\MFVideoReader`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\license\MFVideoReader 内に LICENSE を、AviUtl\readme\MFVideoReader 内に Readme.md を (待機) 、
 	# AviUtl\plugins ディレクトリ内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\MFVideoReader`" -Force; Move-Item Readme.md `"${Path}\readme\MFVideoReader`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\MFVideoReader`" -Force; Move-Item Readme.md `"${Path}\readme\MFVideoReader`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\plugins" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -558,19 +558,19 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nWebP Susie Plug-inをダウンロードしています..."
 
 	# WebP Susie Plug-inのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL https://toroidj.github.io/plugin/iftwebp11.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL https://toroidj.github.io/plugin/iftwebp11.zip" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "WebP Susie Plug-inをインストールしています..."
 
 	# WebP Susie Plug-inのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path iftwebp11.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path iftwebp11.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを iftwebp11 ディレクトリに変更
 	Set-Location iftwebp11
 
 	# AviUtl\readme 内に iftwebp ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\iftwebp`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\iftwebp`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に iftwebp.spi を、AviUtl\readme\iftwebp 内に iftwebp.txt をそれぞれ移動
 	Move-Item iftwebp.spi $Path -Force
@@ -593,7 +593,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "ifheifをダウンロードしています..."
 
 	# ifheifのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $ifheifUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $ifheifUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "ifheifをインストールしています..."
@@ -604,13 +604,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# ifheifのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path ifheif.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path ifheif.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをifheifのzipファイルを展開したディレクトリに変更
 	Set-Location "ifheif"
 
 	# AviUtl\readme, AviUtl\license 内に ifheif ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\ifheif`", `"${Path}\license\ifheif`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\ifheif`", `"${Path}\license\ifheif`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に ifheif.spi を、AviUtl\license\ifheif 内に LICENSE と Licenses ディレクトリを、
 	# AviUtl\readme\ifheif 内に Readme.md をそれぞれ移動
@@ -625,7 +625,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n「AviUtlスクリプト一式」をダウンロードしています..."
 
 	# 「AviUtlスクリプト一式」のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/script_20160828.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/script_20160828.zip" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "「AviUtlスクリプト一式」をインストールしています..."
@@ -646,17 +646,17 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# 「AviUtlスクリプト一式」のzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path script_20160828.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path script_20160828.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを script_20160828\script_20160828 ディレクトリに変更
 	Set-Location script_20160828\script_20160828
 
 	# AviUtl\script 内に さつき ディレクトリを、AviUtl\readme 内に AviUtlスクリプト一式 ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\さつき`", `"${Path}\readme\AviUtlスクリプト一式`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\さつき`", `"${Path}\readme\AviUtlスクリプト一式`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\script 内に ANM_ssd と TA_ssd を、AviUtl\readme\AviUtlスクリプト一式 内に readme.txt と 使い方.txt を (待機) 、
 	# AviUtl\script\さつき 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item ANM_ssd `"${Path}\script`" -Force; Move-Item TA_ssd `"${Path}\script`" -Force; Move-Item *.txt `"${Path}\readme\AviUtlスクリプト一式`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item ANM_ssd `"${Path}\script`" -Force; Move-Item TA_ssd `"${Path}\script`" -Force; Move-Item *.txt `"${Path}\readme\AviUtlスクリプト一式`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\script\さつき" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -666,13 +666,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n「値で図形」をダウンロードしています..."
 
 	# 値で図形.obj をダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/値で図形.obj`"" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/値で図形.obj`"" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "「値で図形」をインストールしています..."
 
 	# AviUtl\script 内に Nagomiku ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\Nagomiku`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\Nagomiku`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\script\Nagomiku 内に 値で図形.obj を移動
 	Move-Item "値で図形.obj" "${Path}\script\Nagomiku" -Force
@@ -681,23 +681,23 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n直線スクリプトをダウンロードしています..."
 
 	# 直線スクリプトのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/直線スクリプト.zip`"" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/直線スクリプト.zip`"" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "直線スクリプトをインストールしています..."
 
 	# 直線スクリプトのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"直線スクリプト.zip`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"直線スクリプト.zip`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを 直線スクリプト ディレクトリに変更
 	Set-Location "直線スクリプト"
 
 	# AviUtl\script 内に ちくぼん ディレクトリを、AviUtl\readme, AviUtl\license 内に 直線スクリプト ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\ちくぼん`", `"${Path}\readme\直線スクリプト`", `"${Path}\license\直線スクリプト`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\ちくぼん`", `"${Path}\readme\直線スクリプト`", `"${Path}\license\直線スクリプト`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl\script\ちくぼん 内に 直線.obj を、AviUtl\license\直線スクリプト 内に LICENSE.txt を (待機) 、
 	# AviUtl\readme\直線スクリプト 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item `"直線.obj`" `"${Path}\script\ちくぼん`" -Force; Move-Item LICENSE.txt `"${Path}\license\直線スクリプト`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item `"直線.obj`" `"${Path}\script\ちくぼん`" -Force; Move-Item LICENSE.txt `"${Path}\license\直線スクリプト`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\readme\直線スクリプト" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -728,7 +728,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "LuaJITをダウンロードしています..."
 
 	# LuaJITのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $luaJitUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $luaJitUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "LuaJITをインストールしています..."
@@ -745,13 +745,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# LuaJITのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"LuaJIT_2.1_Win_x86.zip`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"LuaJIT_2.1_Win_x86.zip`" -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをLuaJITのzipファイルを展開したディレクトリに変更
 	Set-Location "LuaJIT_2.1_Win_x86"
 
 	# AviUtl\readme, AviUtl\license 内に LuaJIT ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\LuaJIT`", `"${Path}\license\LuaJIT`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\LuaJIT`", `"${Path}\license\LuaJIT`" -ItemType Directory -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に lua51.dll を、AviUtl\readme\LuaJIT 内に README と doc を、AviUtl\license\LuaJIT 内に
 	# COPYRIGHT と About-This-Build.txt をそれぞれ移動
@@ -797,12 +797,12 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "."
 
 		# zipファイルをダウンロード (待機)
-		Start-Process -FilePath curl.exe -ArgumentList "-OL $downloadUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+		Start-Process -FilePath curl.exe -ArgumentList "-OL $downloadUrl" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 		Write-Host -NoNewline "."
 
 		# zipファイルを展開 (待機)
-		Start-Process powershell -ArgumentList "-command Expand-Archive -Path Aviutl_${repoName}_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+		Start-Process powershell -ArgumentList "-command Expand-Archive -Path Aviutl_${repoName}_*.zip -Force" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 	}
 
 	Write-Host " 完了"
@@ -818,14 +818,14 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	foreach ($hwEncoder in $hwEncoders.GetEnumerator()) {
 		# エンコーダーの実行ファイルのパスを格納
 		Set-Location "Aviutl_$($hwEncoder.Key)_*"
-		$extdir = ($TempPath)
+		$extdir = ${TempPath}
 		$encoderPath = Join-Path -Path $extdir -ChildPath "exe_files\$($hwEncoder.Key)C\x86\$($hwEncoder.Value)"
 		Set-Location ..
 
 		# エンコーダーの実行ファイルの有無を確認
 		if (Test-Path $encoderPath) {
 			# ハードウェアエンコードできるかチェック
-			$process = Start-Process -FilePath $encoderPath -ArgumentList "--check-hw" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait -PassThru
+			$process = Start-Process -FilePath $encoderPath -ArgumentList "--check-hw" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait -PassThru
 
 			# ExitCode が 0 = 使用可能な場合はインストール
 			if ($process.ExitCode -eq 0) {
@@ -908,7 +908,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "Microsoft Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロードしています..."
 
 		# Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロード (待機)
-		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 		Write-Host "完了"
 		Write-Host "Microsoft Visual C++ 2015-20xx Redistributable (x86) のインストールを行います。"
@@ -916,7 +916,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 
 		# Visual C++ 2015-20xx Redistributable (x86) のインストーラーを実行 (待機)
 			# 自動インストールオプションを追加 by Atolycs (20250106)
-		Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+		Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 		Write-Host "インストーラーが終了しました。"
 		Write-Host "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 はインストール済みです。"
@@ -942,7 +942,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 				Write-Host -NoNewline "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロードしています..."
 
 				# Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロード (待機)
-				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 				Write-Host "完了"
 				Write-Host "Microsoft Visual C++ 2008 Redistributable - x86 のインストールを行います。"
@@ -950,7 +950,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 
 				# Visual C++ 2008 Redistributable - x86 のインストーラーを実行 (待機)
 					# 自動インストールオプションを追加 by Atolycs (20250106)
-				Start-Process -FilePath vcredist_x86.exe -ArgumentList "/qb" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+				Start-Process -FilePath vcredist_x86.exe -ArgumentList "/qb" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 				Write-Host "インストーラーが終了しました。"
 				break
@@ -971,7 +971,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "Microsoft Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロードしています..."
 
 		# Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロード (待機)
-		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 		Write-Host "完了"
 		Write-Host "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 はインストールされていません。"
@@ -993,7 +993,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 				Write-Host -NoNewline "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロードしています..."
 
 				# Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロード (待機)
-				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 				Write-Host "完了"
 				Write-Host "`r`nMicrosoft Visual C++ 2015-20xx Redistributable (x86) と`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストールを行います。"
@@ -1011,7 +1011,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 
 				# Visual C++ 2015-20xx Redistributable (x86) のインストーラーを実行 (待機)
 					# 自動インストールオプションを追加 by Atolycs (20250106)
-				Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
+				Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory ${TempPath} -WindowStyle Hidden -Wait
 
 				Write-Host "インストーラーが終了しました。"
 				Write-Host "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストールをスキップしました。"
@@ -1078,7 +1078,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	#Set-Location ..
 
 	# tmp ディレクトリを削除
-	Remove-Item ($TempPath) -Recurse
+	Remove-Item ${TempPath} -Recurse
 
 	Write-Host "完了"
 

--- a/aviutl-installer.cmd
+++ b/aviutl-installer.cmd
@@ -54,6 +54,12 @@ param (
 	[string]$Path = "C:\Applications\AviUtl"
 )
 
+function New-TempDirectory() {
+  $path = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+}
+
+$TempPath = New-TempDirectory
+
 # バージョン情報を記載
 $VerNum = "1.1.20"
 $ReleaseDate = "2025-03-01"
@@ -124,13 +130,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	$AISDownloadUrl = $AisGithubApi.assets.browser_download_url
 
 	# 本体のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $AISDownloadUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $AISDownloadUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# $AisTagName から先頭の「v」を削除
 	$AisTagName = $AisTagName.Substring(1)
 
 	# 本体のzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl-installer_$AisTagName.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl-installer_$AisTagName.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# 展開後のzipを削除
 	Remove-Item aviutl-installer_$($AisTagName).zip
@@ -232,16 +238,16 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nAviUtlをインストールするフォルダを作成しています..."
 
 	# $Path ディレクトリを作成する (待機)
-	Start-Process powershell -ArgumentList "-command New-Item $Path -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item $Path -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に plugins, script, license, readme の4つのディレクトリを作成する (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\plugins`", `"${Path}\script`", `"${Path}\license`", `"${Path}\readme`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\plugins`", `"${Path}\script`", `"${Path}\license`", `"${Path}\readme`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "`r`n一時的にファイルを保管するフォルダを作成しています..."
 
 	# tmp ディレクトリを作成する (待機)
-	Start-Process powershell -ArgumentList "-command New-Item tmp -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item ($TempPath) -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを tmp ディレクトリに変更
 	Set-Location tmp
@@ -256,14 +262,14 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "「登録されている拡張子は表示しない」を無効にしています..."
 
 		# C:\Applications\AviUtl-Installer-Script ディレクトリを作成する (待機)
-		Start-Process powershell -ArgumentList "-command New-Item `"C:\Applications\AviUtl-Installer-Script`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+		Start-Process powershell -ArgumentList "-command New-Item `"C:\Applications\AviUtl-Installer-Script`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 		# "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion" をバックアップ (待機)
-		Start-Process powershell -ArgumentList "-command reg export `"HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion`" `"C:\Applications\AviUtl-Installer-Script\Backup.reg`"" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+		Start-Process powershell -ArgumentList "-command reg export `"HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion`" `"C:\Applications\AviUtl-Installer-Script\Backup.reg`"" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 		# "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" がない場合、作成する (待機)
 		if (!(Test-Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced")) {
-			Start-Process powershell -ArgumentList "-command New-Item `"HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+			Start-Process powershell -ArgumentList "-command New-Item `"HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 		}
 
 		# レジストリを書き換えて「登録されている拡張子は表示しない」を無効化
@@ -274,19 +280,19 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nAviUtl本体 (version 1.10) をダウンロードしています..."
 
 	# AviUtl version 1.10のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/aviutl110.zip" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/aviutl110.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "AviUtl本体をインストールしています..."
 
 	# AviUtlのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl110.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path aviutl110.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを aviutl110 ディレクトリに変更
 	Set-Location aviutl110
 
 	# AviUtl\readme 内に aviutl ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\aviutl`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\aviutl`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に aviutl.exe と aviutl.txt を移動
 	Move-Item "aviutl.exe", "aviutl.txt" $Path -Force
@@ -301,22 +307,22 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n拡張編集Plugin version 0.92をダウンロードしています..."
 
 	# 拡張編集Plugin version 0.92のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/exedit92.zip" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL http://spring-fragrance.mints.ne.jp/aviutl/exedit92.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "拡張編集Pluginをインストールしています..."
 
 	# 拡張編集Pluginのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path exedit92.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path exedit92.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを exedit92 ディレクトリに変更
 	Set-Location exedit92
 
 	# AviUtl\readme 内に exedit ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\exedit`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\exedit`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# exedit.ini は使用せず、かつこの後の処理で邪魔になるので削除する (待機)
-	Start-Process powershell -ArgumentList "-command Remove-Item exedit.ini" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Remove-Item exedit.ini" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内にファイルを全て移動
 	Move-Item * $Path -Force
@@ -341,22 +347,22 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "patch.aul (謎さうなフォーク版) をダウンロードしています..."
 
 	# patch.aul (謎さうなフォーク版) のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $patchAulUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $patchAulUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "patch.aul (謎さうなフォーク版) をインストールしています..."
 
 	# patch.aulのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path patch.aul_*.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path patch.aul_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをpatch.aulのzipファイルを展開したディレクトリに変更
 	Set-Location "patch.aul_*"
 
 	# AviUtl\license 内に patch-aul ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\license\patch-aul`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\license\patch-aul`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に patch.aul を (待機) 、AviUtl\license\patch-aul 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item patch.aul $Path -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item patch.aul $Path -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\license\patch-aul" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -382,7 +388,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "L-SMASH Works (Mr-Ojii版) をダウンロードしています..."
 
 	# L-SMASH Works (Mr-Ojii版) のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $lSmashWorksUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $lSmashWorksUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "L-SMASH Works (Mr-Ojii版) をインストールしています..."
@@ -393,17 +399,17 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# L-SMASH Worksのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path L-SMASH-Works_*.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path L-SMASH-Works_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをL-SMASH Worksのzipファイルを展開したディレクトリに変更
 	Set-Location "L-SMASH-Works_*"
 
 	# AviUtl\readme, AviUtl\license 内に l-smash_works ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\l-smash_works`", `"${Path}\license\l-smash_works`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\l-smash_works`", `"${Path}\license\l-smash_works`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\plugins ディレクトリ内に lw*.au* を、AviUtl\readme\l-smash_works 内に READM* を (待機) 、
 	# AviUtl\license\l-smash_works 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item lw*.au* `"${Path}\plugins`" -Force; Move-Item READM* `"${Path}\readme\l-smash_works`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item lw*.au* `"${Path}\plugins`" -Force; Move-Item READM* `"${Path}\readme\l-smash_works`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\license\l-smash_works" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -433,23 +439,23 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "InputPipePluginをダウンロードしています..."
 
 	# InputPipePluginのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $InputPipePluginUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $InputPipePluginUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "InputPipePluginをインストールしています..."
 
 	# InputPipePluginのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path InputPipePlugin_*.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path InputPipePlugin_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをInputPipePluginのzipファイルを展開したディレクトリに変更
 	Set-Location "InputPipePlugin_*\InputPipePlugin"
 
 	# AviUtl\readme, AviUtl\license 内に inputPipePlugin ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\inputPipePlugin`", `"${Path}\license\inputPipePlugin`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\inputPipePlugin`", `"${Path}\license\inputPipePlugin`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\license\inputPipePlugin 内に LICENSE を、AviUtl\readme\inputPipePlugin 内に Readme.md を (待機) 、
 	# AviUtl\plugins ディレクトリ内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\inputPipePlugin`" -Force; Move-Item Readme.md `"${Path}\readme\inputPipePlugin`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\inputPipePlugin`" -Force; Move-Item Readme.md `"${Path}\readme\inputPipePlugin`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\plugins" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -469,7 +475,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "x264guiExをダウンロードしています..."
 
 	# x264guiExのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $x264guiExUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $x264guiExUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "x264guiExをインストールしています..."
@@ -480,7 +486,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# x264guiExのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path x264guiEx_*.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path x264guiEx_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをx264guiExのzipファイルを展開したディレクトリに変更
 	Set-Location "x264guiEx_*\x264guiEx_*"
@@ -495,7 +501,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Set-Location ..\exe_files
 
 	# AviUtl ディレクトリ内に exe_files ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\exe_files`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\exe_files`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\exe_files 内に現在のディレクトリのファイルを全て移動
 	Move-Item * "${Path}\exe_files" -Force
@@ -504,7 +510,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Set-Location ..
 
 	# AviUtl\readme 内に x264guiEx ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\x264guiEx`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\x264guiEx`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\readme\x264guiEx 内に x264guiEx_readme.txt を移動
 	Move-Item x264guiEx_readme.txt "${Path}\readme\x264guiEx" -Force
@@ -526,23 +532,23 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "MFVideoReaderをダウンロードしています..."
 
 	# MFVideoReaderのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $MFVideoReaderUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $MFVideoReaderUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "MFVideoReaderをインストールしています..."
 
 	# MFVideoReaderのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path MFVideoReader_*.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path MFVideoReader_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをMFVideoReaderのzipファイルを展開したディレクトリに変更
 	Set-Location "MFVideoReader_*\MFVideoReader"
 
 	# AviUtl\readme, AviUtl\license 内に MFVideoReader ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\MFVideoReader`", `"${Path}\license\MFVideoReader`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\MFVideoReader`", `"${Path}\license\MFVideoReader`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\license\MFVideoReader 内に LICENSE を、AviUtl\readme\MFVideoReader 内に Readme.md を (待機) 、
 	# AviUtl\plugins ディレクトリ内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\MFVideoReader`" -Force; Move-Item Readme.md `"${Path}\readme\MFVideoReader`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item LICENSE `"${Path}\license\MFVideoReader`" -Force; Move-Item Readme.md `"${Path}\readme\MFVideoReader`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\plugins" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -552,19 +558,19 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nWebP Susie Plug-inをダウンロードしています..."
 
 	# WebP Susie Plug-inのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL https://toroidj.github.io/plugin/iftwebp11.zip" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL https://toroidj.github.io/plugin/iftwebp11.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "WebP Susie Plug-inをインストールしています..."
 
 	# WebP Susie Plug-inのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path iftwebp11.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path iftwebp11.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを iftwebp11 ディレクトリに変更
 	Set-Location iftwebp11
 
 	# AviUtl\readme 内に iftwebp ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\iftwebp`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\iftwebp`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に iftwebp.spi を、AviUtl\readme\iftwebp 内に iftwebp.txt をそれぞれ移動
 	Move-Item iftwebp.spi $Path -Force
@@ -587,7 +593,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "ifheifをダウンロードしています..."
 
 	# ifheifのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $ifheifUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $ifheifUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "ifheifをインストールしています..."
@@ -598,13 +604,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# ifheifのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path ifheif.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path ifheif.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをifheifのzipファイルを展開したディレクトリに変更
 	Set-Location "ifheif"
 
 	# AviUtl\readme, AviUtl\license 内に ifheif ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\ifheif`", `"${Path}\license\ifheif`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\ifheif`", `"${Path}\license\ifheif`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に ifheif.spi を、AviUtl\license\ifheif 内に LICENSE と Licenses ディレクトリを、
 	# AviUtl\readme\ifheif 内に Readme.md をそれぞれ移動
@@ -619,7 +625,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n「AviUtlスクリプト一式」をダウンロードしています..."
 
 	# 「AviUtlスクリプト一式」のzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/script_20160828.zip" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/script_20160828.zip" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "「AviUtlスクリプト一式」をインストールしています..."
@@ -640,17 +646,17 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# 「AviUtlスクリプト一式」のzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path script_20160828.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path script_20160828.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを script_20160828\script_20160828 ディレクトリに変更
 	Set-Location script_20160828\script_20160828
 
 	# AviUtl\script 内に さつき ディレクトリを、AviUtl\readme 内に AviUtlスクリプト一式 ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\さつき`", `"${Path}\readme\AviUtlスクリプト一式`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\さつき`", `"${Path}\readme\AviUtlスクリプト一式`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\script 内に ANM_ssd と TA_ssd を、AviUtl\readme\AviUtlスクリプト一式 内に readme.txt と 使い方.txt を (待機) 、
 	# AviUtl\script\さつき 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item ANM_ssd `"${Path}\script`" -Force; Move-Item TA_ssd `"${Path}\script`" -Force; Move-Item *.txt `"${Path}\readme\AviUtlスクリプト一式`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item ANM_ssd `"${Path}\script`" -Force; Move-Item TA_ssd `"${Path}\script`" -Force; Move-Item *.txt `"${Path}\readme\AviUtlスクリプト一式`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\script\さつき" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -660,13 +666,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n「値で図形」をダウンロードしています..."
 
 	# 値で図形.obj をダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/値で図形.obj`"" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/値で図形.obj`"" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "「値で図形」をインストールしています..."
 
 	# AviUtl\script 内に Nagomiku ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\Nagomiku`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\Nagomiku`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\script\Nagomiku 内に 値で図形.obj を移動
 	Move-Item "値で図形.obj" "${Path}\script\Nagomiku" -Force
@@ -675,23 +681,23 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`n直線スクリプトをダウンロードしています..."
 
 	# 直線スクリプトのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/直線スクリプト.zip`"" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL `"https://ss1.xrea.com/menkuri.s270.xrea.com/aviutl-installer-script/scripts/直線スクリプト.zip`"" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "直線スクリプトをインストールしています..."
 
 	# 直線スクリプトのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"直線スクリプト.zip`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"直線スクリプト.zip`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリを 直線スクリプト ディレクトリに変更
 	Set-Location "直線スクリプト"
 
 	# AviUtl\script 内に ちくぼん ディレクトリを、AviUtl\readme, AviUtl\license 内に 直線スクリプト ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\ちくぼん`", `"${Path}\readme\直線スクリプト`", `"${Path}\license\直線スクリプト`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\script\ちくぼん`", `"${Path}\readme\直線スクリプト`", `"${Path}\license\直線スクリプト`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl\script\ちくぼん 内に 直線.obj を、AviUtl\license\直線スクリプト 内に LICENSE.txt を (待機) 、
 	# AviUtl\readme\直線スクリプト 内にその他のファイルをそれぞれ移動
-	Start-Process powershell -ArgumentList "-command Move-Item `"直線.obj`" `"${Path}\script\ちくぼん`" -Force; Move-Item LICENSE.txt `"${Path}\license\直線スクリプト`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Move-Item `"直線.obj`" `"${Path}\script\ちくぼん`" -Force; Move-Item LICENSE.txt `"${Path}\license\直線スクリプト`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 	Move-Item * "${Path}\readme\直線スクリプト" -Force
 
 	# カレントディレクトリを tmp ディレクトリに変更
@@ -722,7 +728,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "LuaJITをダウンロードしています..."
 
 	# LuaJITのzipファイルをダウンロード (待機)
-	Start-Process -FilePath curl.exe -ArgumentList "-OL $luaJitUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process -FilePath curl.exe -ArgumentList "-OL $luaJitUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	Write-Host "完了"
 	Write-Host -NoNewline "LuaJITをインストールしています..."
@@ -739,13 +745,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	}
 
 	# LuaJITのzipファイルを展開 (待機)
-	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"LuaJIT_2.1_Win_x86.zip`" -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command Expand-Archive -Path `"LuaJIT_2.1_Win_x86.zip`" -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# カレントディレクトリをLuaJITのzipファイルを展開したディレクトリに変更
 	Set-Location "LuaJIT_2.1_Win_x86"
 
 	# AviUtl\readme, AviUtl\license 内に LuaJIT ディレクトリを作成 (待機)
-	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\LuaJIT`", `"${Path}\license\LuaJIT`" -ItemType Directory -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+	Start-Process powershell -ArgumentList "-command New-Item `"${Path}\readme\LuaJIT`", `"${Path}\license\LuaJIT`" -ItemType Directory -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 	# AviUtl ディレクトリ内に lua51.dll を、AviUtl\readme\LuaJIT 内に README と doc を、AviUtl\license\LuaJIT 内に
 	# COPYRIGHT と About-This-Build.txt をそれぞれ移動
@@ -791,12 +797,12 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "."
 
 		# zipファイルをダウンロード (待機)
-		Start-Process -FilePath curl.exe -ArgumentList "-OL $downloadUrl" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+		Start-Process -FilePath curl.exe -ArgumentList "-OL $downloadUrl" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 		Write-Host -NoNewline "."
 
 		# zipファイルを展開 (待機)
-		Start-Process powershell -ArgumentList "-command Expand-Archive -Path Aviutl_${repoName}_*.zip -Force" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+		Start-Process powershell -ArgumentList "-command Expand-Archive -Path Aviutl_${repoName}_*.zip -Force" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 	}
 
 	Write-Host " 完了"
@@ -812,14 +818,14 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	foreach ($hwEncoder in $hwEncoders.GetEnumerator()) {
 		# エンコーダーの実行ファイルのパスを格納
 		Set-Location "Aviutl_$($hwEncoder.Key)_*"
-		$extdir = (Get-Location).Path
+		$extdir = ($TempPath)
 		$encoderPath = Join-Path -Path $extdir -ChildPath "exe_files\$($hwEncoder.Key)C\x86\$($hwEncoder.Value)"
 		Set-Location ..
 
 		# エンコーダーの実行ファイルの有無を確認
 		if (Test-Path $encoderPath) {
 			# ハードウェアエンコードできるかチェック
-			$process = Start-Process -FilePath $encoderPath -ArgumentList "--check-hw" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait -PassThru
+			$process = Start-Process -FilePath $encoderPath -ArgumentList "--check-hw" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait -PassThru
 
 			# ExitCode が 0 = 使用可能な場合はインストール
 			if ($process.ExitCode -eq 0) {
@@ -902,7 +908,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "Microsoft Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロードしています..."
 
 		# Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロード (待機)
-		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 		Write-Host "完了"
 		Write-Host "Microsoft Visual C++ 2015-20xx Redistributable (x86) のインストールを行います。"
@@ -910,7 +916,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 
 		# Visual C++ 2015-20xx Redistributable (x86) のインストーラーを実行 (待機)
 			# 自動インストールオプションを追加 by Atolycs (20250106)
-		Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+		Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 		Write-Host "インストーラーが終了しました。"
 		Write-Host "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 はインストール済みです。"
@@ -936,7 +942,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 				Write-Host -NoNewline "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロードしています..."
 
 				# Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロード (待機)
-				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 				Write-Host "完了"
 				Write-Host "Microsoft Visual C++ 2008 Redistributable - x86 のインストールを行います。"
@@ -944,7 +950,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 
 				# Visual C++ 2008 Redistributable - x86 のインストーラーを実行 (待機)
 					# 自動インストールオプションを追加 by Atolycs (20250106)
-				Start-Process -FilePath vcredist_x86.exe -ArgumentList "/qb" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+				Start-Process -FilePath vcredist_x86.exe -ArgumentList "/qb" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 				Write-Host "インストーラーが終了しました。"
 				break
@@ -965,7 +971,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 		Write-Host -NoNewline "Microsoft Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロードしています..."
 
 		# Visual C++ 2015-20xx Redistributable (x86) のインストーラーをダウンロード (待機)
-		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+		Start-Process -FilePath curl.exe -ArgumentList "-OL https://aka.ms/vs/17/release/vc_redist.x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 		Write-Host "完了"
 		Write-Host "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 はインストールされていません。"
@@ -987,7 +993,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 				Write-Host -NoNewline "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロードしています..."
 
 				# Visual C++ 2008 Redistributable - x86 のインストーラーをダウンロード (待機)
-				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+				Start-Process -FilePath curl.exe -ArgumentList "-OL https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 				Write-Host "完了"
 				Write-Host "`r`nMicrosoft Visual C++ 2015-20xx Redistributable (x86) と`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストールを行います。"
@@ -1005,7 +1011,7 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 
 				# Visual C++ 2015-20xx Redistributable (x86) のインストーラーを実行 (待機)
 					# 自動インストールオプションを追加 by Atolycs (20250106)
-				Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -Wait
+				Start-Process -FilePath vc_redist.x86.exe -ArgumentList "/install /passive" -WorkingDirectory ($TempPath) -WindowStyle Hidden -Wait
 
 				Write-Host "インストーラーが終了しました。"
 				Write-Host "`r`nMicrosoft Visual C++ 2008 Redistributable - x86 のインストールをスキップしました。"
@@ -1069,10 +1075,10 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`nインストールに使用した不要なファイルを削除しています..."
 
 	# カレントディレクトリをスクリプトファイルのあるディレクトリに変更
-	Set-Location ..
+	#Set-Location ..
 
 	# tmp ディレクトリを削除
-	Remove-Item tmp -Recurse
+	Remove-Item ($TempPath) -Recurse
 
 	Write-Host "完了"
 


### PR DESCRIPTION
一時フォルダの生成方法を変更しました。

今まではスクリプトと同じディレクトリにありましたが、コードを見た感じエラーが発生して処理がスキップされた際などに移動が変になってしまい、最悪ユーザープロファイルを破壊してしまう可能性がありました。

このため、ユーザープロファイルの一時領域(`%temp%`)にランダム文字列のフォルダを生成し、ダウンロードしたファイルなどを配置するように仕組みを作りました。

こちらはいかがでしょうか?