### PR TITLE
apm.jsonの読み込み、書き込み関連のバグを修正

### DIFF
--- a/aviutl-installer.cmd
+++ b/aviutl-installer.cmd
@@ -1031,13 +1031,13 @@ if (($AisTagName -ne $Version) -and ($scriptFileRoot -eq $AisRootDir)) {
 	Write-Host -NoNewline "`r`napm.json を作成しています..."
 
 	# $apmJsonHash をJSON形式に変換し、apm.json として出力する
-	ConvertTo-Json $apmJsonHash -Depth 8 -Compress | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\apm.json"
+	ConvertTo-Json $apmJsonHash -Depth 8 | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\apm.json"
 
 	Write-Host "完了"
 	Write-Host -NoNewline "`r`nais.json を作成しています..."
 
 	# $aisJsonHash をJSON形式に変換し、ais.json として出力する
-	ConvertTo-Json $aisJsonHash -Depth 8 -Compress | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\ais.json"
+	ConvertTo-Json $aisJsonHash -Depth 8 | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\ais.json"
 
 	Write-Host "完了"
 	Write-Host -NoNewline "`r`nデスクトップにショートカットファイルを作成しています..."

--- a/script_files/必須プラグイン・スクリプトを更新する.cmd
+++ b/script_files/必須プラグイン・スクリプトを更新する.cmd
@@ -166,7 +166,7 @@ Write-Host -NoNewline "`r`napm.json を確認しています..."
 # apm.json が存在する場合、$apmJsonHash に読み込み、$apmJsonExist に true を格納
 $apmJsonExist = $false
 if (Test-Path "${Path}\apm.json") {
-	$apmJsonHash = Get-Content "${Path}\apm.json" | ConvertFrom-JsonEditable
+	$apmJsonHash = (Get-Content "${Path}\apm.json" -Raw) | ConvertFrom-JsonEditable
 	$apmJsonExist = $true
 
 # apm.json が存在しない場合、apm.json の元になるハッシュテーブルを用意して $apmJsonHash に代入
@@ -1720,13 +1720,13 @@ Get-ChildItem -Path $Path -Recurse | Unblock-File
 Write-Host -NoNewline "`r`napm.json を作成しています..."
 
 # $apmJsonHash をJSON形式に変換し、apm.json として出力する
-ConvertTo-Json $apmJsonHash -Depth 8 -Compress | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\apm.json"
+ConvertTo-Json $apmJsonHash -Depth 8 | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\apm.json"
 
 Write-Host "完了"
 Write-Host -NoNewline "`r`nais.json を作成しています..."
 
 # $aisJsonHash をJSON形式に変換し、ais.json として出力する
-ConvertTo-Json $aisJsonHash -Depth 8 -Compress | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\ais.json"
+ConvertTo-Json $aisJsonHash -Depth 8 | ForEach-Object { $_ + "`n" } | ForEach-Object { [Text.Encoding]::UTF8.GetBytes($_) } | Set-Content -Encoding Byte -Path "${Path}\ais.json"
 
 Write-Host "完了"
 Write-Host -NoNewline "`r`n更新に使用した不要なファイルを削除しています..."


### PR DESCRIPTION
修正内容:

- apm.jsonをオリジナルのapmと同じ形式（ConvertTo-Jsonの-compressなし）で出力するように変更しました。

- オリジナルのapmで作成されたapm.json（修正後のものも含む）を正しく読み込めるように処理を変更しました。

Fixes #24

影響範囲:

- apm.jsonの出力処理と読み込み処理に関連します。

動作確認:

- 複数のapm.jsonファイルでテストを行い、正しく読み込めることを確認しました。
